### PR TITLE
Fix CSV header mismatch

### DIFF
--- a/fetch_saninsen2025_asahi.py
+++ b/fetch_saninsen2025_asahi.py
@@ -140,6 +140,7 @@ def parse_candidates(html: str, default_district: str) -> list[dict]:
             "seitou": party,
             "title": name,
             "detail": f"{age}歳",
+            "age": age,
             "tubohantei": "",
             "tubonaiyou": "",
             "tuboURL": "",
@@ -176,6 +177,7 @@ def main() -> None:
         "seitou",
         "title",
         "detail",
+        "age",
         "tubohantei",
         "tubonaiyou",
         "tuboURL",
@@ -183,7 +185,7 @@ def main() -> None:
         "uraganenaiyou",
         "uraganeURL",
     ]
-    with open("saninsen2025_candidates.csv", "w", newline="", encoding="utf-8-sig") as f:
+    with open("saninsen2025_candidates.csv", "w", newline="", encoding="utf-8") as f:
         writer = csv.DictWriter(f, fieldnames=keys)
         writer.writeheader()
         writer.writerows(all_rows)


### PR DESCRIPTION
## Summary
- include `age` field when scraping candidates
- add `age` to CSV header and remove BOM by writing in UTF-8

## Testing
- `python -m py_compile fetch_saninsen2025_asahi.py`

------
https://chatgpt.com/codex/tasks/task_e_685ca073fc388329a7398656579e4dce