### PR TITLE
Add yomi column and note source limitations

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,7 @@
+This repository scrapes Asahi Shimbun's '参院選2025 立候補予定者一覧' to build CSV data.
+
+Known limitations of source data:
+- The pages listing 2025 candidates currently show only kanji names, ages, and party status. They do **not** provide official name readings (ふりがな).
+- Past election result blocks on the same pages include readings, but they correspond to previous elections.
+
+Because official readings are missing, `fetch_saninsen2025_asahi.py` generates the `yomi` column using automatic kanji-to-hiragana conversion via pykakasi. If accurate readings become available, update the scraper accordingly.

--- a/fetch_saninsen2025_asahi.py
+++ b/fetch_saninsen2025_asahi.py
@@ -29,6 +29,11 @@ FALLBACK_CODES.append("C01")
 _kakasi = kakasi()
 
 
+def to_hiragana(text: str) -> str:
+    """Return hiragana reading for given Japanese text."""
+    return "".join(d["hira"] for d in _kakasi.convert(text))
+
+
 def slugify_jp(text: str) -> str:
     """Romanize Japanese text and return a slug suitable for IDs."""
     romaji = "".join(d["hepburn"] for d in _kakasi.convert(text))
@@ -157,7 +162,10 @@ def parse_candidates(html: str, default_district: str) -> list[dict]:
         age_idx = next((i for i, p in enumerate(parts) if p.isdigit()), -1)
         if age_idx == -1 or age_idx + 1 >= len(parts):
             continue
-        name = "".join(parts[:age_idx])
+        name_tokens = parts[:age_idx]
+        name = "".join(name_tokens)
+        surname = name_tokens[0] if name_tokens else name
+        yomi = to_hiragana(surname)
         age = parts[age_idx]
         party_status = parts[age_idx + 1]
 
@@ -181,6 +189,7 @@ def parse_candidates(html: str, default_district: str) -> list[dict]:
             "senkyoku": senkyoku,
             "seitou": party,
             "title": name,
+            "yomi": yomi,
             "detail": f"{age}歳",
             "age": age,
             "tubohantei": "",
@@ -218,6 +227,7 @@ def main() -> None:
         "senkyoku",
         "seitou",
         "title",
+        "yomi",
         "detail",
         "age",
         "tubohantei",


### PR DESCRIPTION
## Summary
- generate candidate surname reading using pykakasi
- export `yomi` column to CSV
- document missing official readings in AGENTS.md

## Testing
- `python -m py_compile fetch_saninsen2025_asahi.py`
- `python fetch_saninsen2025_asahi.py`

------
https://chatgpt.com/codex/tasks/task_e_685cdbe43c8483298f9e5fcab2e9af33